### PR TITLE
refactor: 將所有 argparse CLI 進入點統一整合到 main.py 的 click 介面

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from workflow import main as workflow_main, opt_strategy
 from run_strategy import run_strategy_logic
 from sj_trading.simulation import simulate as simulate_cli, simulate_trades
+from sj_trading.download_data import download_data
 from sj_trading.config import Config
 from sj_trading.dataloader import Dataloader
 import pandas as pd
@@ -204,6 +205,24 @@ def run(data_file, input_file, output_file, start_date, end_date, skip_dates):
         end_date=end_date,
         skip_dates=skip_dates
     )
+
+@cli.command(name="download")
+@click.option(
+    "--start-date",
+    type=str,
+    default=None,
+    help="下載開始日期 (格式: YYYY-MM-DD)。預設為 1000 天前。"
+)
+@click.option(
+    "--end-date",
+    type=str,
+    default=None,
+    help="下載結束日期 (格式: YYYY-MM-DD)。預設為 7 天後。"
+)
+def download(start_date, end_date):
+    """下載 yfinance 股價資料"""
+    download_data(start_date=start_date, end_date=end_date)
+
 
 cli.add_command(simulate_cli, "sim")
 

--- a/src/run_strategy.py
+++ b/src/run_strategy.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 from datetime import datetime
 from pathlib import Path
@@ -168,40 +167,3 @@ def run_strategy_logic(data_file, input_file, output_file, start_date=None, end_
         print("所有策略執行完畢，但未產生任何交易訊號。")
 
 
-def run_strategy_cli():
-    """
-    CLI 進入點，用於根據儲存的最佳參數重新執行策略。
-    """
-    parser = argparse.ArgumentParser(description="使用最佳化後的參數執行單洄測，並產生交易訊號。")
-    parser.add_argument(
-        "--data-file",
-        type=str,
-        default=Config.YFINANCE_FILE_NAME,
-        help=f"包含市場數據的 CSV 檔案 (預設: {Config.YFINANCE_FILE_NAME})"
-    )
-    parser.add_argument(
-        "--input-file",
-        type=str,
-        default="output/best_strategy_params.json",
-        help="包含最佳策略參數的 JSON 檔案 (預設: output/best_strategy_params.json)"
-    )
-    parser.add_argument(
-        "--output-file",
-        type=str,
-        default="output/strategy_trades.json",
-        help="儲存交易訊號的輸出 JSON 檔案 (預設: output/strategy_trades.json)"
-    )
-    parser.add_argument("--start-date", type=str, help="覆寫所有策略的開始日期 (YYYY-MM-DD)。")
-    parser.add_argument("--end-date", type=str, help="覆寫所有策略的結束日期 (YYYY-MM-DD)。")
-    parser.add_argument("--skip-dates", type=str, help="覆寫所有策略要跳過的日期 (YYYY-MM-DD,YYYY-MM-DD)。")
-
-    args = parser.parse_args()
-
-    run_strategy_logic(
-        data_file=args.data_file,
-        input_file=args.input_file,
-        output_file=args.output_file,
-        start_date=args.start_date,
-        end_date=args.end_date,
-        skip_dates=args.skip_dates
-    )

--- a/src/sj_trading/download_data.py
+++ b/src/sj_trading/download_data.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import os
 from datetime import datetime, timedelta
@@ -74,31 +73,3 @@ def download_data(start_date=None, end_date=None):
     print(f"✅ 資料已成功儲存至 {output_filename}")
 
 
-def download_data_cli():
-    """
-    為 download_data 提供命令列介面。
-    """
-    parser = argparse.ArgumentParser(description="下載 yfinance 股價資料")
-    parser.add_argument(
-        "--start-date",
-        type=str,
-        default=None,
-        help="下載開始日期 (格式: YYYY-MM-DD)。預設為 1000 天前。"
-    )
-    parser.add_argument(
-        "--end-date",
-        type=str,
-        default=None,
-        help="下載結束日期 (格式: YYYY-MM-DD)。預設為 7 天後。"
-    )
-    args = parser.parse_args()
-
-    # 驗證日期格式
-    for date_str in [args.start_date, args.end_date]:
-        if date_str:
-            try:
-                datetime.strptime(date_str, '%Y-%m-%d')
-            except ValueError:
-                parser.error(f"日期格式錯誤: {date_str}。請使用 YYYY-MM-DD 格式。")
-
-    download_data(start_date=args.start_date, end_date=args.end_date)

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -1,4 +1,3 @@
-import argparse
 import backtrader as bt
 import pandas as pd
 from datetime import datetime
@@ -248,8 +247,6 @@ def print_backtest_result(bt_result, num_transactions: int, level=logging.INFO, 
     logger.log(level,f"Cumulative Return: {bt_result['cumulative_return']:.2%}")
     logger.log(level,f"Annual Return: {annual_return:.2%}")
 
-import argparse
-
 def opt_strategy(filename: str = Config.YFINANCE_FILE_NAME, start_date: str = None, end_date: str = None):
     dataframe =  Dataloader.read_csv(filename)
     if dataframe.empty:
@@ -370,56 +367,3 @@ def opt_strategy(filename: str = Config.YFINANCE_FILE_NAME, start_date: str = No
     print("🎉 優化完成！")
     # for x in watch_list:
     #     print_backtest_result(level=logging.INFO, bt_result=x["bt_result"], num_transactions=5)
-
-
-
-def main():
-    """
-    主執行入口點，用於解析命令列參數並執行 opt_strategy
-    """
-    parser = argparse.ArgumentParser(description="演算法交易框架 - 策略回測優化")
-
-    # 預設的回測日期
-    default_start_date = (datetime.now() - timedelta(days=365)).strftime('%Y-%m-%d')
-    default_end_date = (datetime.now() + timedelta(days=7)).strftime('%Y-%m-%d')
-
-    parser.add_argument(
-        "--filename",
-        type=str,
-        default=Config.YFINANCE_FILE_NAME,
-        help=f"要讀取的 CSV 資料檔案路徑 (預設: {Config.YFINANCE_FILE_NAME})"
-    )
-    parser.add_argument(
-        "--start-date",
-        type=str,
-        default=default_start_date,
-        help=f"回測開始日期 (格式: YYYY-MM-DD，預設: {default_start_date})"
-    )
-    parser.add_argument(
-        "--end-date",
-        type=str,
-        default=default_end_date,
-        help=f"回測結束日期 (格式: YYYY-MM-DD，預設: {default_end_date})"
-    )
-
-    args = parser.parse_args()
-
-    # 驗證日期格式
-    for date_str in [args.start_date, args.end_date]:
-        if date_str:
-            try:
-                datetime.strptime(date_str, '%Y-%m-%d')
-            except ValueError:
-                parser.error(f"日期格式錯誤: {date_str}。請使用 YYYY-MM-DD 格式。")
-
-    print(f"🔄 開始執行 opt_strategy，使用資料檔案: {args.filename}, 日期範圍: {args.start_date} to {args.end_date}")
-
-    opt_strategy(filename=args.filename, start_date=args.start_date, end_date=args.end_date)
-
-
-
-
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
此重構將所有分散的 `argparse` 命令列進入點整合到 `src/main.py` 中，
使用 `click` 作為唯一的 CLI 介面。

- 移除了 `src/run_strategy.py`、`src/workflow.py` 和 `src/sj_trading/download_data.py` 中的 `argparse` 相關程式碼。
- 在 `src/main.py` 中新增了 `download` 命令，以整合資料下載功能。
- 現在 `src/main.py` 是專案唯一的命令列進入點。